### PR TITLE
OIDC support added with doorkeeper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,5 +109,5 @@ jobs:
         if: failure()
         with:
           name: screenshots
-          path: ${{ github.workspace }}/tmp/screenshots
+          path: ${{ github.workspace }}/rails-auth-server/tmp/screenshots
           if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
           bundler-cache: true
           working-directory: rails-auth-server
 
+      - name: Generate PEM file
+        run: openssl genrsa -out config/keys/private.pem 2048
+
       - name: Run tests
         env:
           RAILS_ENV: test

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ rails console
 app = Doorkeeper::Application.create!(
   name: "Awesome Client",
   redirect_uri: "http://localhost:12000 http://localhost:9000",  # Replace with your SPA URL for client1 and client2
-  scopes: "public",
+  scopes: "openid email profile",
   trusted: true,
   confidential: false
 )

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OAuth 2 Demo - Rails Auth Server + SPA Clients
 
-This project demonstrates an OAuth2 setup using a **Ruby on Rails authorization server** (with Doorkeeper + Devise) and two separate **JavaScript single-page clients** (Client1 and Client2).
+This project demonstrates an OAuth2 setup using a **Ruby on Rails authorization server** (with Doorkeeper + Devise) and two separate **JavaScript single-page clients** (Client1 and Client2). The server also supports **OpenID Connect** for identity authentication flow.
 
 ---
 
@@ -23,6 +23,25 @@ This project demonstrates an OAuth2 setup using a **Ruby on Rails authorization 
 cd rails-auth-server
 bundle install
 rails db:setup
+```
+
+### Generate RSA private key for OpenID Connect
+
+The OpenID Connect implementation requires an RSA private key for signing JWT tokens. Before starting the server, check if you need to generate this key:
+
+**Note: Make sure you are in the `rails-auth-server` directory for these steps.**
+
+1. Look for the file `config/keys/private.pem`
+2. If this file does not exist, generate it with:
+
+```bash
+openssl genrsa -out config/keys/private.pem 2048
+```
+
+3. For security, you may want to restrict file permissions:
+
+```bash
+chmod 600 config/keys/private.pem
 ```
 
 Create a Doorkeeper application:
@@ -93,6 +112,38 @@ const AUTH_SERVER_URL = 'http://localhost:4000';
 * `GET /oauth/authorize` – Begin auth flow
 * `POST /oauth/token` – Exchange code / refresh token
 * `GET /api/v1/profiles/me` – Protected API endpoint
+
+### OpenID Connect Endpoints
+* `GET /.well-known/openid-configuration` - OpenID Connect discovery document
+* `GET /oauth/userinfo` - User information endpoint
+* `GET /oauth/jwks` - JSON Web Key Set for verifying tokens
+
+---
+
+## 🔐 OpenID Connect Support
+
+This project includes support for OpenID Connect on top of OAuth2. OpenID Connect extends OAuth2 by providing identity verification and authentication details alongside authorization.
+
+### OpenID Connect Features
+* **ID Tokens**: JWT format tokens containing authenticated user information
+* **Standard Claims**: Access to user profile information such as email, name, and profile
+* **Discovery Document**: Well-known endpoint for clients to discover server capabilities
+* **Userinfo Endpoint**: Additional endpoint to fetch user details
+
+### Using OpenID Connect
+To use OpenID Connect in your client applications, request the appropriate scopes:
+* `openid` - Required for OpenID Connect flow
+* `profile` - Access to user's name and basic profile info
+* `email` - Access to user's email address
+
+Example authorization request with OpenID Connect:
+```
+http://localhost:4000/oauth/authorize?
+  client_id=YOUR_CLIENT_ID&
+  redirect_uri=http://localhost:12000&
+  response_type=code&
+  scope=openid profile email
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ const AUTH_SERVER_URL = 'http://localhost:4000';
 ### OpenID Connect Endpoints
 * `GET /.well-known/openid-configuration` - OpenID Connect discovery document
 * `GET /oauth/userinfo` - User information endpoint
-* `GET /oauth/jwks` - JSON Web Key Set for verifying tokens
+* `GET /oauth/discovery/keys` - JSON Web Key Set for verifying tokens
 
 ---
 

--- a/client1/index.html
+++ b/client1/index.html
@@ -110,7 +110,7 @@
         if (!tokenData) {
           const authUrl = `${AUTH_SERVER_URL}/oauth/authorize?` +
                           `response_type=code&client_id=${CLIENT_ID}` +
-                          `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}&scope=public`;
+                          `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}&scope=openid email profile`;
           window.location.href = authUrl;
           return;
         }

--- a/client2/index.html
+++ b/client2/index.html
@@ -110,7 +110,7 @@
         if (!tokenData) {
           const authUrl = `${AUTH_SERVER_URL}/oauth/authorize?` +
                           `response_type=code&client_id=${CLIENT_ID}` +
-                          `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}&scope=public`;
+                          `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}&scope=openid email profile`;
           window.location.href = authUrl;
           return;
         }

--- a/rails-auth-server/.gitignore
+++ b/rails-auth-server/.gitignore
@@ -32,3 +32,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore credentials file
+private_key.pem

--- a/rails-auth-server/.gitignore
+++ b/rails-auth-server/.gitignore
@@ -34,4 +34,4 @@
 /config/master.key
 
 # Ignore credentials file
-private_key.pem
+config/keys/private.pem

--- a/rails-auth-server/Gemfile
+++ b/rails-auth-server/Gemfile
@@ -67,3 +67,5 @@ gem "doorkeeper", "~> 5.8"
 gem "devise", "~> 4.9"
 
 gem "rack-cors", "~> 3.0",  require: "rack/cors"
+
+gem "doorkeeper-openid_connect", "~> 1.8"

--- a/rails-auth-server/Gemfile.lock
+++ b/rails-auth-server/Gemfile.lock
@@ -110,6 +110,10 @@ GEM
       warden (~> 1.2.3)
     doorkeeper (5.8.2)
       railties (>= 5)
+    doorkeeper-openid_connect (1.8.11)
+      doorkeeper (>= 5.5, < 5.9)
+      jwt (>= 2.5)
+      ostruct (>= 0.5)
     dotenv (3.1.8)
     drb (2.2.3)
     ed25519 (1.4.0)
@@ -137,6 +141,8 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.12.2)
+    jwt (3.0.0)
+      base64
     kamal (2.6.1)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -378,6 +384,7 @@ DEPENDENCIES
   debug
   devise (~> 4.9)
   doorkeeper (~> 5.8)
+  doorkeeper-openid_connect (~> 1.8)
   importmap-rails
   jbuilder
   kamal

--- a/rails-auth-server/app/controllers/api/v1/profiles_controller.rb
+++ b/rails-auth-server/app/controllers/api/v1/profiles_controller.rb
@@ -1,6 +1,6 @@
 # app/controllers/api/v1/profiles_controller.rb
 class Api::V1::ProfilesController < ApplicationController
-  before_action :doorkeeper_authorize!
+  before_action -> { doorkeeper_authorize! :profile }
 
   def me
     render json: current_resource_owner.as_json.merge(application_name: doorkeeper_token.application.name)

--- a/rails-auth-server/config/initializers/doorkeeper.rb
+++ b/rails-auth-server/config/initializers/doorkeeper.rb
@@ -243,7 +243,7 @@ Doorkeeper.configure do
   # https://doorkeeper.gitbook.io/guides/ruby-on-rails/scopes
 
   default_scopes :read, :public
-  optional_scopes :write
+  optional_scopes :write, :openid, :profile, :email
 
   # Allows to restrict only certain scopes for grant_type.
   # By default, all the scopes will be available for all the grant types.

--- a/rails-auth-server/config/initializers/doorkeeper.rb
+++ b/rails-auth-server/config/initializers/doorkeeper.rb
@@ -7,10 +7,12 @@ Doorkeeper.configure do
 
   # This block will be called to check whether the resource owner is authenticated or not.
   resource_owner_authenticator do
-    current_user || warden.authenticate!(scope: :user)
-    # Put your resource owner authentication logic here.
-    # Example implementation:
-    #   User.find_by(id: session[:user_id]) || redirect_to(new_user_session_url)
+    if current_user
+      current_user
+    else
+      warden.authenticate!(scope: :user)
+      nil
+    end
   end
 
   # If you didn't skip applications controller from Doorkeeper routes in your application routes.rb
@@ -363,7 +365,7 @@ Doorkeeper.configure do
   #   https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.2
   #   https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.3
   #
-  # grant_flows %w[authorization_code client_credentials]
+  grant_flows %w[authorization_code client_credentials implicit_oidc]
 
   # Allows to customize OAuth grant flows that +each+ application support.
   # You can configure a custom block (or use a class respond to `#call`) that must

--- a/rails-auth-server/config/initializers/doorkeeper_openid_connect.rb
+++ b/rails-auth-server/config/initializers/doorkeeper_openid_connect.rb
@@ -63,7 +63,7 @@ Doorkeeper::OpenidConnect.configure do
       resource_owner.email
     end
 
-    # normal_claim :name, scope: :profile do |resource_owner|
+    # normal_claim :profile, scope: :profile do |resource_owner|
     #   resource_owner&.name
     # end
   end

--- a/rails-auth-server/config/initializers/doorkeeper_openid_connect.rb
+++ b/rails-auth-server/config/initializers/doorkeeper_openid_connect.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+Doorkeeper::OpenidConnect.configure do
+  issuer do |resource_owner, application|
+    "https://localhost:300" # Replace with your actual issuer URL
+  end
+
+  signing_key do
+    OpenSSL::PKey::RSA.new(File.read(Rails.root.join('private_key.pem')))
+  end
+
+  subject_types_supported [:public]
+
+  resource_owner_from_access_token do |access_token|
+    # Example implementation:
+    # User.find_by(id: access_token.resource_owner_id)
+  end
+
+  auth_time_from_resource_owner do |resource_owner|
+    # Example implementation:
+    # resource_owner.current_sign_in_at
+  end
+
+  reauthenticate_resource_owner do |resource_owner, return_to|
+    # Example implementation:
+    # store_location_for resource_owner, return_to
+    # sign_out resource_owner
+    # redirect_to new_user_session_url
+  end
+
+  # Depending on your configuration, a DoubleRenderError could be raised
+  # if render/redirect_to is called at some point before this callback is executed.
+  # To avoid the DoubleRenderError, you could add these two lines at the beginning
+  #  of this callback: (Reference: https://github.com/rails/rails/issues/25106)
+  #   self.response_body = nil
+  #   @_response_body = nil
+  select_account_for_resource_owner do |resource_owner, return_to|
+    # Example implementation:
+    # store_location_for resource_owner, return_to
+    # redirect_to account_select_url
+  end
+
+  subject do |resource_owner, application|
+    # Example implementation:
+    # resource_owner.id
+
+    # or if you need pairwise subject identifier, implement like below:
+    # Digest::SHA256.hexdigest("#{resource_owner.id}#{URI.parse(application.redirect_uri).host}#{'your_secret_salt'}")
+  end
+
+  # Protocol to use when generating URIs for the discovery endpoint,
+  # for example if you also use HTTPS in development
+  # protocol do
+  #   :https
+  # end
+
+  # Expiration time on or after which the ID Token MUST NOT be accepted for processing. (default 120 seconds).
+  # expiration 600
+
+  # Example claims:
+  claims do
+    normal_claim :email do |resource_owner|
+      resource_owner.email
+    end
+
+    # normal_claim :_bar_ do |resource_owner|
+    #   resource_owner.bar
+    # end
+  end
+end

--- a/rails-auth-server/config/initializers/doorkeeper_openid_connect.rb
+++ b/rails-auth-server/config/initializers/doorkeeper_openid_connect.rb
@@ -5,15 +5,12 @@ Doorkeeper::OpenidConnect.configure do
     "https://localhost:300" # Replace with your actual issuer URL
   end
 
-  signing_key do
-    OpenSSL::PKey::RSA.new(File.read(Rails.root.join('private_key.pem')))
-  end
+  signing_key File.read(Rails.root.join("config/keys/private.pem"))
 
   subject_types_supported [:public]
 
   resource_owner_from_access_token do |access_token|
-    # Example implementation:
-    # User.find_by(id: access_token.resource_owner_id)
+    User.find_by(id: access_token.resource_owner_id)
   end
 
   auth_time_from_resource_owner do |resource_owner|
@@ -57,14 +54,17 @@ Doorkeeper::OpenidConnect.configure do
   # Expiration time on or after which the ID Token MUST NOT be accepted for processing. (default 120 seconds).
   # expiration 600
 
-  # Example claims:
   claims do
-    normal_claim :email do |resource_owner|
+    normal_claim :sub, scope: :openid do |resource_owner|
+      "user-#{resource_owner.id}"
+    end
+
+    normal_claim :email, scope: :email do |resource_owner|
       resource_owner.email
     end
 
-    # normal_claim :_bar_ do |resource_owner|
-    #   resource_owner.bar
+    # normal_claim :name, scope: :profile do |resource_owner|
+    #   resource_owner&.name
     # end
   end
 end

--- a/rails-auth-server/config/initializers/doorkeeper_openid_connect.rb
+++ b/rails-auth-server/config/initializers/doorkeeper_openid_connect.rb
@@ -7,7 +7,7 @@ Doorkeeper::OpenidConnect.configure do
 
   signing_key File.read(Rails.root.join("config/keys/private.pem"))
 
-  subject_types_supported [:public]
+  subject_types_supported [ :public ]
 
   resource_owner_from_access_token do |access_token|
     User.find_by(id: access_token.resource_owner_id)

--- a/rails-auth-server/config/locales/doorkeeper_openid_connect.en.yml
+++ b/rails-auth-server/config/locales/doorkeeper_openid_connect.en.yml
@@ -1,0 +1,23 @@
+en:
+  doorkeeper:
+    scopes:
+      openid: 'Authenticate your account'
+      profile: 'View your profile information'
+      email: 'View your email address'
+      address: 'View your physical address'
+      phone: 'View your phone number'
+    errors:
+      messages:
+        login_required: 'The authorization server requires end-user authentication'
+        consent_required: 'The authorization server requires end-user consent'
+        interaction_required: 'The authorization server requires end-user interaction'
+        account_selection_required: 'The authorization server requires end-user account selection'
+    openid_connect:
+      errors:
+        messages:
+          # Configuration error messages
+          resource_owner_from_access_token_not_configured: 'Failure due to Doorkeeper::OpenidConnect.configure.resource_owner_from_access_token missing configuration.'
+          auth_time_from_resource_owner_not_configured: 'Failure due to Doorkeeper::OpenidConnect.configure.auth_time_from_resource_owner missing configuration.'
+          reauthenticate_resource_owner_not_configured: 'Failure due to Doorkeeper::OpenidConnect.configure.reauthenticate_resource_owner missing configuration.'
+          select_account_for_resource_owner_not_configured: 'Failure due to Doorkeeper::OpenidConnect.configure.select_account_for_resource_owner missing configuration.'
+          subject_not_configured: 'ID Token generation failed due to Doorkeeper::OpenidConnect.configure.subject missing configuration.'

--- a/rails-auth-server/config/routes.rb
+++ b/rails-auth-server/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  use_doorkeeper_openid_connect
   namespace :api do
     namespace :v1 do
       get "profiles/me"

--- a/rails-auth-server/db/migrate/20250616134611_create_doorkeeper_openid_connect_tables.rb
+++ b/rails-auth-server/db/migrate/20250616134611_create_doorkeeper_openid_connect_tables.rb
@@ -1,0 +1,15 @@
+class CreateDoorkeeperOpenidConnectTables < ActiveRecord::Migration[8.0]
+  def change
+    create_table :oauth_openid_requests do |t|
+      t.references :access_grant, null: false, index: true
+      t.string :nonce, null: false
+    end
+
+    add_foreign_key(
+      :oauth_openid_requests,
+      :oauth_access_grants,
+      column: :access_grant_id,
+      on_delete: :cascade
+    )
+  end
+end

--- a/rails-auth-server/db/schema.rb
+++ b/rails-auth-server/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_05_064109) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_16_134611) do
   create_table "oauth_access_grants", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "resource_owner_id", null: false
     t.bigint "application_id", null: false
@@ -54,6 +54,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_05_064109) do
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
+  create_table "oauth_openid_requests", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "access_grant_id", null: false
+    t.string "nonce", null: false
+    t.index ["access_grant_id"], name: "index_oauth_openid_requests_on_access_grant_id"
+  end
+
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -68,4 +74,5 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_05_064109) do
 
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
+  add_foreign_key "oauth_openid_requests", "oauth_access_grants", column: "access_grant_id", on_delete: :cascade
 end

--- a/rails-auth-server/test/controllers/api/v1/profiles_controller_test.rb
+++ b/rails-auth-server/test/controllers/api/v1/profiles_controller_test.rb
@@ -9,7 +9,7 @@ class Api::V1::ProfilesControllerTest < ActionDispatch::IntegrationTest
       resource_owner_id: @user.id,
       application: @application,
       expires_in: 1.hour,
-      scopes: "public"
+      scopes: "openid email profile"
     )
   end
 


### PR DESCRIPTION
This pull request introduces OpenID Connect (OIDC) support to the OAuth2 setup, enhancing identity authentication and user profile access capabilities. Key changes include updates to the configuration, scopes, endpoints, and database schema to integrate OIDC functionality seamlessly.

### OpenID Connect Integration:

* **Enhanced Documentation**: Updated `README.md` to include details about OpenID Connect support, endpoints, features, and instructions for generating an RSA private key for signing JWT tokens. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R28-R46) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R116-R147)
* **OIDC Scopes and Flows**: Added `openid`, `email`, and `profile` scopes to `rails-auth-server/config/initializers/doorkeeper.rb` and enabled the `implicit_oidc` grant flow. [[1]](diffhunk://#diff-378b7bdc3faad56b81724a3b58bc69cc49661a65392dc45440b69dd5969773abL244-R246) [[2]](diffhunk://#diff-378b7bdc3faad56b81724a3b58bc69cc49661a65392dc45440b69dd5969773abL366-R368)
* **OIDC Configuration**: Introduced `rails-auth-server/config/initializers/doorkeeper_openid_connect.rb` to configure issuer, signing key, claims, and resource owner handling for OIDC.

### Code Changes for OIDC Support:

* **Authorization Updates**: Modified `rails-auth-server/app/controllers/api/v1/profiles_controller.rb` to require the `profile` scope for accessing user profile data.
* **Client Updates**: Updated `client1/index.html` and `client2/index.html` to request OIDC scopes (`openid email profile`) during authorization. [[1]](diffhunk://#diff-7b6c002048c64652615b53ed8ef725bda10803863c2e77cbfe015e1c1785aea4L113-R113) [[2]](diffhunk://#diff-92afa3247bb76d58d99634ebecbb5436a26e727ac3cde74738c43acbfedcc738L113-R113)

### Database and Routing Updates:

* **Schema Changes**: Added `oauth_openid_requests` table to support OIDC nonce tracking via migration and updated `rails-auth-server/db/schema.rb`. [[1]](diffhunk://#diff-def3e99480b05b862d0272b9d64bd5b61fec5d648dc2de18dfea4bcbb5ba85d2R1-R15) [[2]](diffhunk://#diff-5c7804d08072923fedc4a665b985730ae5e2574aea1169b9e5b1f6c7da1091cdL13-R13) [[3]](diffhunk://#diff-5c7804d08072923fedc4a665b985730ae5e2574aea1169b9e5b1f6c7da1091cdR57-R62) [[4]](diffhunk://#diff-5c7804d08072923fedc4a665b985730ae5e2574aea1169b9e5b1f6c7da1091cdR77)
* **Routing Enhancements**: Integrated OIDC routes using `use_doorkeeper_openid_connect` in `rails-auth-server/config/routes.rb`.

### Miscellaneous Updates:

* **Dependencies**: Added `doorkeeper-openid_connect` gem to `rails-auth-server/Gemfile`.
* **File Management**: Updated `.gitignore` to exclude the RSA private key file (`config/keys/private.pem`).
* **Localization**: Added OIDC-related error messages and scope descriptions to `rails-auth-server/config/locales/doorkeeper_openid_connect.en.yml`.